### PR TITLE
Implement feed highlighting and reload

### DIFF
--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -68,10 +68,32 @@
   document.querySelectorAll('.chip').forEach(el=>{ el.onclick=()=>{ document.querySelectorAll('.chip').forEach(c=>c.classList.remove('active')); el.classList.add('active'); loadHistory(); }; });
   document.querySelector('.chip[data-tf="1m"]').classList.add('active');
 
-  async function switchFeed(feed){ await post('/api/ctrl/switch_feed', {feed}); msg(`Фид переключен: ${feed}`) }
+  async function switchFeed(feed){
+    await post('/api/ctrl/switch_feed', {feed});
+    await loadStatus();
+    await loadHistory();
+    msg(`Фид переключен: ${feed}`);
+  }
   function post(url, body){ return fetch(url,{ method:'POST', headers:{'Content-Type':'application/json', ...hdrs()}, body: body? JSON.stringify(body): null }).then(r=>{ if(!r.ok) throw new Error('request failed'); return r.json(); }) }
 
-  async function loadStatus(){ const r=await fetch('/api/status',{headers:hdrs()}); if(!r.ok) return; const s=await r.json(); $('#status').textContent = `mode=${s.mode} | ${s.symbol}/${s.tf} | feed=${s.feed} | equity=${(s.equity||0).toFixed(2)}` }
+  async function loadStatus(){
+    const r = await fetch('/api/status',{headers:hdrs()});
+    if(!r.ok) return;
+    const s = await r.json();
+    $('#status').textContent = `mode=${s.mode} | ${s.symbol}/${s.tf} | feed=${s.feed} | equity=${(s.equity||0).toFixed(2)}`;
+    const randomBtn = $('#feed-random');
+    const restBtn = $('#feed-rest');
+    if(s.feed==='random'){
+      randomBtn.classList.add('active');
+      restBtn.classList.remove('active');
+    }else if(s.feed==='rest'){
+      restBtn.classList.add('active');
+      randomBtn.classList.remove('active');
+    }else{
+      randomBtn.classList.remove('active');
+      restBtn.classList.remove('active');
+    }
+  }
 
   function msg(t){ const el=$('#aria-msg'); el.textContent=t; setTimeout(()=>el.textContent='Привет! Я помогу 🌸', 4000) }
 

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -19,6 +19,7 @@
   .chip{padding:6px 10px;border:1px solid var(--line);border-radius:999px;cursor:pointer}
   .chip.active{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0}
   .btn{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0;border-radius:10px;padding:10px 12px;cursor:pointer;font-weight:600}
+  .btn.active{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0}
   .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--text)}
   select,input{background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:10px;padding:8px}
   #chart{height:380px}


### PR DESCRIPTION
## Summary
- refresh status and history after switching feeds to keep the UI up to date
- highlight the active feed button based on /api/status responses
- add styling for active feed buttons to match chip appearance

## Testing
- go test ./... *(hangs, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68d52bd57858832398ea1e93e927a752