### PR TITLE
Improve feed toggle clarity and button states

### DIFF
--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -68,11 +68,28 @@
   document.querySelectorAll('.chip').forEach(el=>{ el.onclick=()=>{ document.querySelectorAll('.chip').forEach(c=>c.classList.remove('active')); el.classList.add('active'); loadHistory(); }; });
   document.querySelector('.chip[data-tf="1m"]').classList.add('active');
 
+  function updateFeedButtons(feed){
+    const randomBtn = $('#feed-random');
+    const restBtn = $('#feed-rest');
+    randomBtn.classList.toggle('active', feed === 'random');
+    restBtn.classList.toggle('active', feed === 'rest');
+  }
+
   async function switchFeed(feed){
-    await post('/api/ctrl/switch_feed', {feed});
-    await loadStatus();
-    await loadHistory();
-    msg(`Фид переключен: ${feed}`);
+    const randomBtn = $('#feed-random');
+    const restBtn = $('#feed-rest');
+    randomBtn.disabled = true;
+    restBtn.disabled = true;
+    try{
+      await post('/api/ctrl/switch_feed', {feed});
+      updateFeedButtons(feed);
+      await loadStatus();
+      await loadHistory();
+      msg(`Фид переключен: ${feed}`);
+    } finally {
+      randomBtn.disabled = false;
+      restBtn.disabled = false;
+    }
   }
   function post(url, body){ return fetch(url,{ method:'POST', headers:{'Content-Type':'application/json', ...hdrs()}, body: body? JSON.stringify(body): null }).then(r=>{ if(!r.ok) throw new Error('request failed'); return r.json(); }) }
 
@@ -81,18 +98,7 @@
     if(!r.ok) return;
     const s = await r.json();
     $('#status').textContent = `mode=${s.mode} | ${s.symbol}/${s.tf} | feed=${s.feed} | equity=${(s.equity||0).toFixed(2)}`;
-    const randomBtn = $('#feed-random');
-    const restBtn = $('#feed-rest');
-    if(s.feed==='random'){
-      randomBtn.classList.add('active');
-      restBtn.classList.remove('active');
-    }else if(s.feed==='rest'){
-      restBtn.classList.add('active');
-      randomBtn.classList.remove('active');
-    }else{
-      randomBtn.classList.remove('active');
-      restBtn.classList.remove('active');
-    }
+    updateFeedButtons(s.feed);
   }
 
   function msg(t){ const el=$('#aria-msg'); el.textContent=t; setTimeout(()=>el.textContent='Привет! Я помогу 🌸', 4000) }

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -18,9 +18,33 @@
   .space{flex:1}
   .chip{padding:6px 10px;border:1px solid var(--line);border-radius:999px;cursor:pointer}
   .chip.active{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0}
-  .btn{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0;border-radius:10px;padding:10px 12px;cursor:pointer;font-weight:600}
-  .btn.active{background:linear-gradient(90deg,var(--brand),var(--brand2));color:#0b0f17;border:0}
-  .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--text)}
+  /* Buttons: base = neutral; active/primary = gradient */
+  .btn{
+    background:transparent;
+    border:1px solid var(--line);
+    color:var(--text);
+    border-radius:10px;
+    padding:10px 12px;
+    cursor:pointer;
+    font-weight:600;
+    transition:.15s ease-in-out;
+  }
+  .btn:hover{ border-color:#2a3550 }
+  /* primary actions keep gradient explicitly */
+  .btn-primary{
+    background:linear-gradient(90deg,var(--brand),var(--brand2));
+    color:#0b0f17;
+    border:0;
+  }
+  /* toggled state (e.g., active feed) */
+  .btn.active{
+    background:linear-gradient(90deg,var(--brand),var(--brand2));
+    color:#0b0f17;
+    border:0;
+  }
+  .btn:disabled{ opacity:.6; cursor:not-allowed }
+  /* legacy alias; safe no-op override */
+  .btn.ghost{ /* same as .btn (neutral) */ }
   select,input{background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:10px;padding:8px}
   #chart{height:380px}
   .bubble{position:fixed;right:16px;bottom:16px;display:flex;gap:10px;align-items:center;background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:10px 12px;box-shadow:0 8px 24px rgba(0,0,0,.25)}
@@ -92,7 +116,7 @@
         <div class="muted" style="font-size:12px">Fees (bps)</div>
         <input id="bt-fees" value='{"makerBps":2,"takerBps":5}'>
       </div>
-      <button class="btn" id="bt-run">Run backtest</button>
+      <button class="btn btn-primary" id="bt-run">Run backtest</button>
       <a id="bt-zip" class="btn ghost" style="display:none" href="#" download>Download ZIP</a>
       <div class="space"></div>
       <div id="bt-summary" class="muted" style="font-family:ui-monospace,monospace"></div>
@@ -103,6 +127,7 @@
   <div class="card">
     <div style="font-weight:600;margin-bottom:6px">Controls</div>
     <div class="row">
+      <!-- feed-toggles are neutral by default; only .active is highlighted -->
       <button class="btn" id="feed-random">📡 Feed: Random</button>
       <button class="btn" id="feed-rest">📡 Feed: Rest</button>
       <button class="btn ghost" id="save-state">💾 Save</button>


### PR DESCRIPTION
## Summary
- restyle neutral buttons so only active or primary actions receive gradient emphasis
- keep backtest run button highlighted via new `.btn-primary` class while feed toggles start neutral
- centralize feed button state updates and disable controls while switching feeds to avoid duplicate requests

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d57503ca80832384c6c5fc6da418a2