### PR TITLE
Add futures support, DSL strategy APIs, and structured trade events

### DIFF
--- a/internal/backtest/dsl.go
+++ b/internal/backtest/dsl.go
@@ -1,0 +1,225 @@
+package backtest
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type DSLDoc struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Body []byte
+}
+
+var (
+	dslMu       sync.Mutex
+	dslDocs     = map[string]DSLDoc{}
+	selectedDSL string
+)
+
+func SaveDSLDoc(name string, body []byte) DSLDoc {
+	if name == "" {
+		name = "strategy.dsl"
+	}
+	id := "dsl_" + randomID(10)
+	doc := DSLDoc{ID: id, Name: name, Body: append([]byte(nil), body...)}
+	dslMu.Lock()
+	dslDocs[id] = doc
+	dslMu.Unlock()
+	return doc
+}
+
+func ListDSLDocs() []DSLDoc {
+	dslMu.Lock()
+	defer dslMu.Unlock()
+	out := make([]DSLDoc, 0, len(dslDocs))
+	for _, doc := range dslDocs {
+		out = append(out, doc)
+	}
+	return out
+}
+
+func GetDSLDoc(id string) (DSLDoc, bool) {
+	dslMu.Lock()
+	defer dslMu.Unlock()
+	doc, ok := dslDocs[id]
+	return doc, ok
+}
+
+func SelectDSL(id string) bool {
+	dslMu.Lock()
+	defer dslMu.Unlock()
+	if _, ok := dslDocs[id]; !ok {
+		return false
+	}
+	selectedDSL = id
+	return true
+}
+
+func SelectedDSL() string {
+	dslMu.Lock()
+	defer dslMu.Unlock()
+	return selectedDSL
+}
+
+type dslSpec struct {
+	Kind string
+	Args map[string]float64
+}
+
+func compileDSL(body []byte) (dslSpec, error) {
+	spec := dslSpec{Kind: "ema_atr", Args: map[string]float64{}}
+	root, err := parseDSLDocument(body)
+	if err != nil {
+		return spec, err
+	}
+	if v, ok := root["strategy"]; ok {
+		spec.Kind = strings.ToLower(fmt.Sprint(v))
+	}
+	params := map[string]any{}
+	if rawParams, ok := root["params"].(map[string]any); ok {
+		for k, v := range rawParams {
+			params[k] = v
+		}
+	}
+	for k, v := range root {
+		kl := strings.ToLower(k)
+		if kl == "strategy" || kl == "name" || kl == "title" || kl == "params" {
+			continue
+		}
+		if _, exists := params[k]; !exists {
+			params[k] = v
+		}
+	}
+	for k, v := range params {
+		if f, ok := toFloat(v); ok {
+			key := k
+			spec.Args[key] = f
+			lower := strings.ToLower(k)
+			if lower != key {
+				spec.Args[lower] = f
+			}
+		}
+	}
+	if v, ok := spec.Args["r"]; ok {
+		spec.Args["R"] = v
+	}
+	return spec, nil
+}
+
+func toFloat(v any) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case uint64:
+		return float64(val), true
+	case json.Number:
+		if f, err := val.Float64(); err == nil {
+			return f, true
+		}
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+func parseDSLDocument(body []byte) (map[string]any, error) {
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err == nil {
+		return root, nil
+	}
+	return parseNaiveYAML(body)
+}
+
+type yamlFrame struct {
+	indent int
+	data   map[string]any
+}
+
+func parseNaiveYAML(body []byte) (map[string]any, error) {
+	root := map[string]any{}
+	stack := []yamlFrame{{indent: -1, data: root}}
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() {
+		raw := scanner.Text()
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := len(raw) - len(strings.TrimLeft(raw, " \t"))
+		for len(stack) > 1 && indent <= stack[len(stack)-1].indent {
+			stack = stack[:len(stack)-1]
+		}
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		parent := stack[len(stack)-1].data
+		if val == "" {
+			child := map[string]any{}
+			parent[key] = child
+			stack = append(stack, yamlFrame{indent: indent, data: child})
+			continue
+		}
+		parent[key] = parseScalarValue(val)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func parseScalarValue(val string) any {
+	v := strings.TrimSpace(val)
+	if strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"") {
+		v = strings.Trim(v, "\"")
+		return v
+	}
+	if strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'") {
+		v = strings.Trim(v, "'")
+		return v
+	}
+	if strings.EqualFold(v, "true") {
+		return true
+	}
+	if strings.EqualFold(v, "false") {
+		return false
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return f
+	}
+	return v
+}
+
+func randomID(n int) string {
+	if n <= 0 {
+		n = 8
+	}
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err == nil {
+		return hex.EncodeToString(buf)[:n]
+	}
+	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789"
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = alphabet[(i+len(alphabet))%len(alphabet)]
+	}
+	return string(out)
+}

--- a/internal/backtest/runner.go
+++ b/internal/backtest/runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"tradebot/internal/core"
+	"tradebot/internal/data"
 	"tradebot/internal/strategies"
 )
 
@@ -23,16 +24,19 @@ type Params struct {
 	Leverage      float64
 	SlippageBps   float64
 	Fees          FeesConfig
-	StrategyKind  string             // "ema_atr" | "rsi"
-	StrategyArgs  map[string]float64 // fast,slow,atr,R | len,overbought,oversold,R
+	Exchange      string
+	StrategyKind  string         // "ema_atr" | "rsi" | "dsl"
+	StrategyArgs  map[string]any // params for strategy (numbers or ids)
 }
 
 type Trade struct {
 	TS    time.Time `json:"ts"`
+	Event string    `json:"event"`
 	Side  string    `json:"side"`
 	Qty   float64   `json:"qty"`
 	Price float64   `json:"price"`
 	PnL   float64   `json:"pnl"`
+	Fee   float64   `json:"fee"`
 	Note  string    `json:"note"`
 }
 
@@ -55,16 +59,39 @@ type Summary struct {
 	MaxDD      float64 `json:"maxDD"`
 }
 
-type noRisk struct{}
+type leverageRisk struct{ leverage float64 }
 
-func (noRisk) Validate(sig core.Signal, acct core.AccountState, px float64) (core.Signal, error) {
+func (lr leverageRisk) Validate(sig core.Signal, acct core.AccountState, px float64) (core.Signal, error) {
+	if lr.leverage <= 1 {
+		return sig, nil
+	}
+	if sig.Action == core.Buy || sig.Action == core.Sell {
+		sig.SizePct *= lr.leverage
+		if sig.SizePct > lr.leverage {
+			sig.SizePct = lr.leverage
+		}
+	}
 	return sig, nil
 }
 
 // Run — упрощённый бэктест: история тянется прямым REST (spot)
 func Run(p Params) (Result, error) {
-	// 1) загрузим историю свечей чанками (как в /api/history)
-	kl, err := fetchHistorySpot(p.Symbol, p.TF, p.From, p.To)
+	exch := strings.ToLower(p.Exchange)
+	// 1) загрузим историю свечей
+	var kl []kline
+	var err error
+	if exch == "futures" {
+		fr, ferr := data.FetchHistoryFutures(p.Symbol, p.TF, p.From, p.To)
+		err = ferr
+		if err == nil {
+			kl = make([]kline, len(fr))
+			for i, v := range fr {
+				kl[i] = kline{Ts: v.Ts, Open: v.Open, High: v.High, Low: v.Low, Close: v.Close, Vol: v.Vol}
+			}
+		}
+	} else {
+		kl, err = fetchHistorySpot(p.Symbol, p.TF, p.From, p.To)
+	}
 	if err != nil {
 		return Result{}, err
 	}
@@ -74,67 +101,51 @@ func Run(p Params) (Result, error) {
 
 	// 2) инициализируем движок с буферным логом сделок
 	trades := make([]Trade, 0, 256)
-	curTS := kl[0].Ts
-	var posSide string
-	var posQty float64
-	notify := func(msg string) {
-		// попытка распарсить из сообщения цену/направление (простая)
-		t := Trade{TS: curTS, Note: msg}
-		fields := strings.Fields(msg)
-		if len(fields) > 0 {
-			switch fields[0] {
-			case "LONG", "SHORT":
-				side := strings.ToLower(fields[0])
-				t.Side = side
-				if len(fields) >= 3 {
-					if qty, err := strconv.ParseFloat(strings.Trim(fields[2], "@"), 64); err == nil {
-						t.Qty = qty
-						if fields[1] == "open" {
-							posQty = qty
-							posSide = side
-						} else if fields[1] == "add" {
-							posQty += qty
-							posSide = side
-						}
-					}
-				}
-				if len(fields) >= 5 {
-					if price, err := strconv.ParseFloat(strings.Trim(fields[4], "@"), 64); err == nil {
-						t.Price = price
-					}
-				}
-			case "CLOSE":
-				t.Side = posSide
-				t.Qty = posQty
-				if len(fields) >= 3 {
-					if price, err := strconv.ParseFloat(strings.Trim(fields[2], "@"), 64); err == nil {
-						t.Price = price
-					}
-				}
-				if idx := strings.Index(msg, "PnL:"); idx >= 0 {
-					rest := msg[idx+4:]
-					restFields := strings.Fields(rest)
-					if len(restFields) > 0 {
-						if pnl, err := strconv.ParseFloat(strings.Trim(restFields[0], ","), 64); err == nil {
-							t.PnL = pnl
-						}
-					}
-				}
-				posSide = ""
-				posQty = 0
-			}
-		}
-		trades = append(trades, t)
+	feeAccTotal := 0.0
+	roundTripFees := 0.0
+	feeRate := p.Fees.TakerBps / 10000.0
+	if feeRate < 0 {
+		feeRate = 0
 	}
+
 	eq := p.InitialEquity
 	equity := []Point{{TS: kl[0].Ts, Equity: eq}}
 
 	eng := core.NewEngine(core.EngineOpts{
 		Mode:       "backtest",
 		EqUSD:      eq,
-		Risk:       noRisk{}, // отключим обрезание размера — стратегия сама вернёт sizePct
-		NotifyFunc: notify,
-		Trades:     nil, // не пишем в файл в режиме бэктеста
+		Risk:       leverageRisk{leverage: p.Leverage},
+		NotifyFunc: func(string) {},
+		TradeHook: func(ev core.TradeEvent) {
+			if ev.Qty <= 0 || ev.Price <= 0 {
+				return
+			}
+			fee := ev.Price * ev.Qty * feeRate
+			if fee < 0 {
+				fee = 0
+			}
+			feeAccTotal += fee
+
+			switch strings.ToUpper(ev.Event) {
+			case "OPEN", "ADD":
+				roundTripFees += fee
+			case "CLOSE":
+				totalFee := roundTripFees + fee
+				netPnL := ev.PnL - totalFee
+				trades = append(trades, Trade{
+					TS:    ev.TS,
+					Event: ev.Event,
+					Side:  actionToSide(ev.Side),
+					Qty:   ev.Qty,
+					Price: ev.Price,
+					PnL:   netPnL,
+					Fee:   totalFee,
+					Note:  ev.Comment,
+				})
+				roundTripFees = 0
+			}
+		},
+		Trades: nil, // не пишем в файл в режиме бэктеста
 	})
 
 	// 3) стратегия
@@ -142,13 +153,12 @@ func Run(p Params) (Result, error) {
 
 	// 4) цикл по свечам
 	for _, k := range kl {
-		curTS = k.Ts
 		ck := core.Kline{Symbol: p.Symbol, TF: p.TF, Open: k.Open, High: k.High, Low: k.Low, Close: k.Close, Vol: k.Vol, Ts: k.Ts}
 		if err := eng.OnCandle(p.Symbol, p.TF, ck); err != nil {
 			return Result{}, err
 		}
 		s := eng.Snapshot()
-		equity = append(equity, Point{TS: k.Ts, Equity: s.EquityUSD})
+		equity = append(equity, Point{TS: k.Ts, Equity: s.EquityUSD - feeAccTotal})
 	}
 
 	// 5) метрики
@@ -229,18 +239,137 @@ func toInt64(v any) int64 {
 
 // NewStrategyFromParams — адаптер: соберёт реализацию core.Strategy из Params
 func NewStrategyFromParams(p Params) core.Strategy {
-	switch p.StrategyKind {
+	kind := strings.ToLower(p.StrategyKind)
+	args := p.StrategyArgs
+	if args == nil {
+		args = map[string]any{}
+	}
+	switch kind {
+	case "dsl":
+		id := ""
+		if v, ok := args["id"]; ok {
+			id = fmt.Sprint(v)
+		}
+		if id == "" {
+			id = SelectedDSL()
+		}
+		if doc, ok := GetDSLDoc(id); ok {
+			if spec, err := compileDSL(doc.Body); err == nil {
+				compiledArgs := make(map[string]any, len(spec.Args))
+				for k, v := range spec.Args {
+					compiledArgs[k] = v
+				}
+				return strategyFromKind(spec.Kind, compiledArgs)
+			}
+		}
+		kind = "ema_atr"
+	case "", "ema", "ema_atr":
+		kind = "ema_atr"
+	}
+	return strategyFromKind(kind, args)
+}
+
+func strategyFromKind(kind string, args map[string]any) core.Strategy {
+	switch strings.ToLower(kind) {
 	case "rsi":
-		l := int(p.StrategyArgs["len"])
-		ob := p.StrategyArgs["overbought"]
-		os := p.StrategyArgs["oversold"]
-		R := p.StrategyArgs["R"]
+		l := intArg(args, "len", 14)
+		ob := numArg(args, "overbought", 70)
+		os := numArg(args, "oversold", 30)
+		R := numArg(args, "R", 1.5)
 		return strategies.NewRSI(l, ob, os, R)
-	default: // ema_atr
-		f := int(p.StrategyArgs["fast"])
-		s := int(p.StrategyArgs["slow"])
-		a := int(p.StrategyArgs["atr"])
-		R := p.StrategyArgs["R"]
+	default:
+		f := intArg(args, "fast", 9)
+		s := intArg(args, "slow", 21)
+		a := intArg(args, "atr", 14)
+		R := numArg(args, "R", 1.5)
 		return strategies.NewEmaAtr(f, s, a, R)
+	}
+}
+
+func numArg(args map[string]any, key string, def float64) float64 {
+	v, ok := args[key]
+	if !ok {
+		lower := strings.ToLower(key)
+		upper := strings.ToUpper(key)
+		if alt, okAlt := args[lower]; okAlt {
+			v = alt
+			ok = true
+		} else if alt, okAlt := args[upper]; okAlt {
+			v = alt
+			ok = true
+		}
+	}
+	if !ok {
+		return def
+	}
+	switch val := v.(type) {
+	case float64:
+		return val
+	case float32:
+		return float64(val)
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case json.Number:
+		f, err := val.Float64()
+		if err == nil {
+			return f
+		}
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f
+		}
+	default:
+		if f, err := strconv.ParseFloat(fmt.Sprint(v), 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func intArg(args map[string]any, key string, def int) int {
+	v, ok := args[key]
+	if !ok {
+		lower := strings.ToLower(key)
+		upper := strings.ToUpper(key)
+		if alt, okAlt := args[lower]; okAlt {
+			v = alt
+			ok = true
+		} else if alt, okAlt := args[upper]; okAlt {
+			v = alt
+			ok = true
+		}
+	}
+	if !ok {
+		return def
+	}
+	switch val := v.(type) {
+	case int:
+		return val
+	case int64:
+		return int(val)
+	case float64:
+		return int(val)
+	case json.Number:
+		if i, err := val.Int64(); err == nil {
+			return int(i)
+		}
+	case string:
+		if i, err := strconv.Atoi(val); err == nil {
+			return i
+		}
+	}
+	return int(numArg(args, key, float64(def)))
+}
+
+func actionToSide(a core.Action) string {
+	switch a {
+	case core.Buy:
+		return "long"
+	case core.Sell:
+		return "short"
+	default:
+		return "flat"
 	}
 }

--- a/internal/core/tradelog.go
+++ b/internal/core/tradelog.go
@@ -11,6 +11,7 @@ type TradeLogEntry struct {
 	Qty     float64
 	Price   float64
 	PnL     float64
+	Fee     float64
 	Comment string
 }
 

--- a/internal/data/futures_rest.go
+++ b/internal/data/futures_rest.go
@@ -1,0 +1,64 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Kline struct {
+	Ts              time.Time
+	Open, High, Low float64
+	Close           float64
+	Vol             float64
+}
+
+// FetchHistoryFutures fetches Binance UM futures klines via REST.
+func FetchHistoryFutures(symbol, interval string, from, to time.Time) ([]Kline, error) {
+	iv := map[string]string{"1m": "1m", "5m": "5m", "15m": "15m", "1h": "1h"}[interval]
+	if iv == "" {
+		iv = "1m"
+	}
+	out := make([]Kline, 0, 4096)
+	start := from
+	client := &http.Client{Timeout: 10 * time.Second}
+	for start.Before(to) {
+		end := start.Add(24 * time.Hour)
+		if end.After(to) {
+			end = to
+		}
+		url := fmt.Sprintf("https://fapi.binance.com/fapi/v1/klines?symbol=%s&interval=%s&startTime=%d&endTime=%d&limit=1500", symbol, iv, start.UnixMilli(), end.UnixMilli())
+		resp, err := client.Get(url)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("binance futures status %d", resp.StatusCode)
+		}
+		var raw [][]any
+		if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		resp.Body.Close()
+		if len(raw) == 0 {
+			break
+		}
+		for _, k := range raw {
+			ts := toInt64(k[0])
+			out = append(out, Kline{
+				Ts:    time.UnixMilli(ts),
+				Open:  toF64(k[1]),
+				High:  toF64(k[2]),
+				Low:   toF64(k[3]),
+				Close: toF64(k[4]),
+				Vol:   toF64(k[5]),
+			})
+		}
+		last := toInt64(raw[len(raw)-1][0])
+		start = time.UnixMilli(last).Add(time.Millisecond)
+	}
+	return out, nil
+}

--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -7,10 +7,11 @@ import (
 )
 
 type TradeCSV struct {
-	TS              int64
-	Side            string
-	Qty, Price, PnL float64
-	Note            string
+	TS                   int64
+	Event                string
+	Side                 string
+	Qty, Price, PnL, Fee float64
+	Note                 string
 }
 
 type EquityCSV struct {
@@ -26,9 +27,9 @@ func WriteTradesCSV(path string, rows []TradeCSV) error {
 	defer f.Close()
 	w := csv.NewWriter(f)
 	defer w.Flush()
-	w.Write([]string{"ts", "side", "qty", "price", "pnl", "note"})
+	w.Write([]string{"ts", "event", "side", "qty", "price", "pnl", "fee", "note"})
 	for _, r := range rows {
-		w.Write([]string{itoa64(r.TS), r.Side, ftoa(r.Qty), ftoa(r.Price), ftoa(r.PnL), r.Note})
+		w.Write([]string{itoa64(r.TS), r.Event, r.Side, ftoa(r.Qty), ftoa(r.Price), ftoa(r.PnL), ftoa(r.Fee), r.Note})
 	}
 	return nil
 }

--- a/internal/tg/bot.go
+++ b/internal/tg/bot.go
@@ -423,7 +423,7 @@ func formatHistory(rows []core.TradeLogEntry) string {
 	}
 	var b strings.Builder
 	for _, r := range rows {
-		fmt.Fprintf(&b, "%s %s %s %s qty=%.4f px=%.2f pnl=%.2f %s\n", r.TS.Format("2006-01-02 15:04"), r.Symbol, r.TF, r.Event, r.Qty, r.Price, r.PnL, r.Comment)
+		fmt.Fprintf(&b, "%s %s %s %s qty=%.4f px=%.2f pnl=%.2f fee=%.4f %s\n", r.TS.Format("2006-01-02 15:04"), r.Symbol, r.TF, r.Event, r.Qty, r.Price, r.PnL, r.Fee, r.Comment)
 	}
 	return b.String()
 }

--- a/internal/web/history.go
+++ b/internal/web/history.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
+
+	"tradebot/internal/data"
 )
 
 // KlineResp описывает минимальный набор полей свечи для фронтенда.
@@ -33,12 +36,21 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	sym := q.Get("symbol")
 	tf := q.Get("tf")
+	mode := q.Get("mode")
 	fromStr := q.Get("from")
 	toStr := q.Get("to")
 	if sym == "" || tf == "" || fromStr == "" || toStr == "" {
 		http.Error(w, "missing params", http.StatusBadRequest)
 		return
 	}
+
+	if mode == "" {
+		mode = s.DefaultExchange
+	}
+	if mode == "" {
+		mode = "spot"
+	}
+	mode = strings.ToLower(mode)
 
 	from, err1 := time.Parse(time.RFC3339, fromStr)
 	to, err2 := time.Parse(time.RFC3339, toStr)
@@ -47,55 +59,67 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	interval := binIv(tf)
 	var out []KlineResp
-	start := from
-	for start.Before(to) {
-		end := start.Add(24 * time.Hour)
-		if end.After(to) {
-			end = to
-		}
-
-		url := fmt.Sprintf("https://api.binance.com/api/v3/klines?symbol=%s&interval=%s&startTime=%d&endTime=%d&limit=1000", sym, interval, start.UnixMilli(), end.UnixMilli())
-		resp, err := http.Get(url)
+	if mode == "futures" {
+		kl, err := data.FetchHistoryFutures(sym, tf, from, to)
 		if err != nil {
-			http.Error(w, "fetch error", http.StatusBadGateway)
+			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
-		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			http.Error(w, "upstream error", http.StatusBadGateway)
-			return
+		out = make([]KlineResp, 0, len(kl))
+		for _, k := range kl {
+			out = append(out, KlineResp{T: k.Ts.UnixMilli(), O: k.Open, H: k.High, L: k.Low, C: k.Close, V: k.Vol})
 		}
-
-		var raw [][]any
-		if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
-			resp.Body.Close()
-			http.Error(w, "decode", http.StatusBadGateway)
-			return
-		}
-		resp.Body.Close()
-
-		for _, k := range raw {
-			if len(k) < 6 {
-				continue
+	} else {
+		interval := binIv(tf)
+		start := from
+		for start.Before(to) {
+			end := start.Add(24 * time.Hour)
+			if end.After(to) {
+				end = to
 			}
-			ot := toInt64(k[0])
-			out = append(out, KlineResp{
-				T: ot,
-				O: toF64(k[1]),
-				H: toF64(k[2]),
-				L: toF64(k[3]),
-				C: toF64(k[4]),
-				V: toF64(k[5]),
-			})
-		}
 
-		if len(raw) == 0 {
-			break
+			url := fmt.Sprintf("https://api.binance.com/api/v3/klines?symbol=%s&interval=%s&startTime=%d&endTime=%d&limit=1000", sym, interval, start.UnixMilli(), end.UnixMilli())
+			resp, err := http.Get(url)
+			if err != nil {
+				http.Error(w, "fetch error", http.StatusBadGateway)
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				resp.Body.Close()
+				http.Error(w, "upstream error", http.StatusBadGateway)
+				return
+			}
+
+			var raw [][]any
+			if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+				resp.Body.Close()
+				http.Error(w, "decode", http.StatusBadGateway)
+				return
+			}
+			resp.Body.Close()
+
+			for _, k := range raw {
+				if len(k) < 6 {
+					continue
+				}
+				ot := toInt64(k[0])
+				out = append(out, KlineResp{
+					T: ot,
+					O: toF64(k[1]),
+					H: toF64(k[2]),
+					L: toF64(k[3]),
+					C: toF64(k[4]),
+					V: toF64(k[5]),
+				})
+			}
+
+			if len(raw) == 0 {
+				break
+			}
+			lastOt := toInt64(raw[len(raw)-1][0])
+			start = time.UnixMilli(lastOt).Add(time.Millisecond)
 		}
-		lastOt := toInt64(raw[len(raw)-1][0])
-		start = time.UnixMilli(lastOt).Add(time.Millisecond)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/web/strategy.go
+++ b/internal/web/strategy.go
@@ -1,0 +1,91 @@
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"tradebot/internal/backtest"
+)
+
+type strategyListItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (s *Server) handleStrategyUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+		return
+	}
+	name := r.URL.Query().Get("name")
+	var body []byte
+	ct := r.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, "application/json") || strings.HasPrefix(ct, "text/plain") {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read", http.StatusBadRequest)
+			return
+		}
+		body = b
+	} else {
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			http.Error(w, "multipart", http.StatusBadRequest)
+			return
+		}
+		file, hdr, err := r.FormFile("file")
+		if err != nil {
+			http.Error(w, "file required", http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		b, err := io.ReadAll(file)
+		if err != nil {
+			http.Error(w, "read", http.StatusBadRequest)
+			return
+		}
+		body = b
+		if name == "" && hdr != nil {
+			name = hdr.Filename
+		}
+	}
+	doc := backtest.SaveDSLDoc(name, body)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "id": doc.ID})
+}
+
+func (s *Server) handleStrategyList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+		return
+	}
+	docs := backtest.ListDSLDocs()
+	out := make([]strategyListItem, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, strategyListItem{ID: d.ID, Name: d.Name})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+func (s *Server) handleStrategySelect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.ID == "" {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if !backtest.SelectDSL(req.ID) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	s.setSelectedDSL(req.ID)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}

--- a/internal/web/ui/app.js
+++ b/internal/web/ui/app.js
@@ -5,19 +5,42 @@
 
   const chart = LightweightCharts.createChart($('#chart'), { layout:{background:{type:0}, textColor:'#e6edf3'}, grid:{vertLines:{color:'#1f2837'}, horzLines:{color:'#1f2837'}}, timeScale:{timeVisible:true, secondsVisible:false} });
   const series = chart.addCandlestickSeries();
+  let tradeMarkers = [];
+  let modeInitialized = false;
 
   async function loadHistory(){
     const sym = $('#symbol').value; const tf = activeTF();
     const to = new Date(); const from = new Date(to.getTime() - 6*60*60*1000);
-    const url = `/api/history?symbol=${sym}&tf=${tf}&from=${encodeURIComponent(from.toISOString())}&to=${encodeURIComponent(to.toISOString())}`;
+    const mode = $('#bt-mode')?.value || 'spot';
+    const url = `/api/history?symbol=${sym}&tf=${tf}&mode=${mode}&from=${encodeURIComponent(from.toISOString())}&to=${encodeURIComponent(to.toISOString())}`;
     const res = await fetch(url, { headers: hdrs() }); const arr = await res.json();
     series.setData(arr.map(k=>({ time: Math.floor(k.t/1000), open:k.o, high:k.h, low:k.l, close:k.c })));
+    tradeMarkers = [];
+    series.setMarkers(tradeMarkers);
   }
 
   // SSE
   const out = $('#stream');
   const es = new EventSource('/sse');
-  es.onmessage = (e)=>{ try{ const j=JSON.parse(e.data); if(j.type==='candle'&&j.data){ series.update({ time: Math.floor(j.data.t/1000), open:j.data.o,high:j.data.h,low:j.data.l,close:j.data.c }); } out.prepend((JSON.stringify(j,null,2)+"\n")); }catch{ out.prepend(e.data+"\n") } };
+  es.onmessage = (e)=>{ try{ const j=JSON.parse(e.data); if(j.type==='candle'&&j.data){ series.update({ time: Math.floor(j.data.t/1000), open:j.data.o,high:j.data.h,low:j.data.l,close:j.data.c }); }
+    if(j.type==='trade'&&j.data){
+      const d=j.data; const ts=Math.floor(new Date(d.ts).getTime()/1000);
+      let marker=null;
+      if(d.side==='long'){
+        marker={ time:ts, position:'belowBar', color:'#26a69a', shape:'arrowUp', text:(d.note||d.event||'BUY') };
+      } else if(d.side==='short'){
+        marker={ time:ts, position:'aboveBar', color:'#ef5350', shape:'arrowDown', text:(d.note||d.event||'SELL') };
+      } else {
+        const color=(typeof d.pnl==='number' && d.pnl>=0)?'#42a5f5':'#ff7043';
+        const txt = d.note || (typeof d.pnl==='number'?`PnL ${d.pnl.toFixed(2)}`:(d.event||'EXIT'));
+        marker={ time:ts, position:'aboveBar', color, shape:'circle', text:txt };
+      }
+      if(marker){
+        tradeMarkers = [...tradeMarkers, marker].slice(-200);
+        series.setMarkers(tradeMarkers);
+      }
+    }
+    out.prepend((JSON.stringify(j,null,2)+"\n")); }catch{ out.prepend(e.data+"\n") } };
 
   // control buttons
   $('#feed-random').onclick = ()=> switchFeed('random');
@@ -45,7 +68,8 @@
     const strat = $('#bt-strat').value;
     let args = {}; try{ args = JSON.parse($('#bt-args').value||'{}'); }catch{}
     let fees = {}; try{ fees = JSON.parse($('#bt-fees').value||'{}'); }catch{}
-    const body = { symbol:sym, tf, from, to, initialEquity:eq, leverage:lev, slippageBps:0, strategy:strat, args, fees };
+    const exchange = ($('#bt-mode')?.value || 'spot');
+    const body = { symbol:sym, tf, from, to, initialEquity:eq, leverage:lev, slippageBps:0, strategy:strat, args, fees, exchange };
     const res = await fetch('/api/backtest', { method:'POST', headers:{'Content-Type':'application/json', ...hdrs()}, body: JSON.stringify(body) });
     if(!res.ok){ alert('Backtest error'); return }
     const j = await res.json();
@@ -97,12 +121,19 @@
     const r = await fetch('/api/status',{headers:hdrs()});
     if(!r.ok) return;
     const s = await r.json();
-    $('#status').textContent = `mode=${s.mode} | ${s.symbol}/${s.tf} | feed=${s.feed} | equity=${(s.equity||0).toFixed(2)}`;
+    $('#status').textContent = `mode=${s.mode} | ${s.symbol}/${s.tf} | feed=${s.feed} | exchange=${s.exchange||'spot'} | equity=${(s.equity||0).toFixed(2)}`;
+    if(!modeInitialized){
+      const sel = $('#bt-mode'); if(sel && s.exchange){ sel.value = s.exchange; }
+      modeInitialized = true;
+    }
     updateFeedButtons(s.feed);
   }
 
   function msg(t){ const el=$('#aria-msg'); el.textContent=t; setTimeout(()=>el.textContent='Привет! Я помогу 🌸', 4000) }
 
   // init
+  const modeSel = $('#bt-mode');
+  if(modeSel){ modeSel.addEventListener('change', ()=>{ loadHistory(); }); }
+
   loadHistory(); loadStatus();
 })();

--- a/internal/web/ui/index.html
+++ b/internal/web/ui/index.html
@@ -86,6 +86,13 @@
     <div style="font-weight:600;margin-bottom:8px">Backtest</div>
     <div class="row" style="gap:12px; align-items:flex-end; flex-wrap:wrap">
       <div>
+        <div class="muted" style="font-size:12px">Mode</div>
+        <select id="bt-mode">
+          <option value="spot">Spot</option>
+          <option value="futures">Futures</option>
+        </select>
+      </div>
+      <div>
         <div class="muted" style="font-size:12px">From</div>
         <input id="bt-from" type="datetime-local">
       </div>


### PR DESCRIPTION
## Summary
- add a Binance UM futures history fetcher and hook `/api/history` into futures or spot sources based on the requested/default exchange
- extend the backtest engine with exchange selection, leverage-aware sizing, fee tracking, DSL-backed strategy selection, and net-metric reporting
- publish structured trade events through SSE, surface them with chart markers in the UI, and expose endpoints to upload/list/select strategy DSL documents

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d57a4cc90483239e325fbaaaf09f40